### PR TITLE
fix: ignore dist outputs in eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,9 @@ import tseslint from 'typescript-eslint';
 import prettierConfig from 'eslint-config-prettier';
 
 export default tseslint.config(
+  {
+    ignores: ['**/dist/**', '**/*.d.ts', 'node_modules/'],
+  },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   prettierConfig,
@@ -21,6 +24,5 @@ export default tseslint.config(
       '@typescript-eslint/consistent-type-imports': 'error',
       'no-console': ['error', { allow: ['warn', 'error', 'info'] }],
     },
-    ignores: ['dist/', 'node_modules/', '*.d.ts'],
   },
 );


### PR DESCRIPTION
## Summary
- ignore `dist` directories and declaration files in ESLint config to prevent lint errors on build artifacts

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689d87cbecc88321824ffccc78028577