### PR TITLE
chore: fix lint dependency for eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/convict": "^6.1.6",
     "@typescript-eslint/eslint-plugin": "^8.39.1",
     "@typescript-eslint/parser": "^8.39.1",
+    "@typescript-eslint/scope-manager": "^8.39.1",
     "eslint": "^9.33.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.39.1
         version: 8.39.1(eslint@9.33.0)(typescript@5.9.2)
+      '@typescript-eslint/scope-manager':
+        specifier: ^8.39.1
+        version: 8.39.1
       eslint:
         specifier: ^9.33.0
         version: 9.33.0


### PR DESCRIPTION
## Summary
- add @typescript-eslint/scope-manager dependency so lint can run

## Testing
- `pnpm lint`
- `pnpm eslint .`


------
https://chatgpt.com/codex/tasks/task_e_689dbd00ab1883219659af7ccf8600a2