### PR TITLE
chore: configure ts project references and pre-commit linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.tsbuildinfo
+pnpm-debug.log
+

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+pnpm lint-staged

--- a/Docs/Implementation/implementation-stages.md
+++ b/Docs/Implementation/implementation-stages.md
@@ -57,8 +57,8 @@ gantt
 **Tasks:**
 
 - [x] Initialize monorepo with pnpm workspaces
-- [ ] Set up TypeScript configuration with project references
-- [ ] Configure ESLint, Prettier, and Husky pre-commit hooks
+- [x] Set up TypeScript configuration with project references
+- [x] Configure ESLint, Prettier, and Husky pre-commit hooks
 - [ ] Set up basic CI/CD pipeline (GitHub Actions)
 - [ ] Create Docker development environment
 - [ ] Set up PostgreSQL and Redis containers

--- a/Docs/Implementation/implementation-summary.md
+++ b/Docs/Implementation/implementation-summary.md
@@ -69,7 +69,7 @@ This project follows a comprehensive documentation architecture designed for bot
 - ✅ **Technical Planning**: Comprehensive PRD, architecture design, and technology stack analysis
 - ✅ **Development Workflow**: AI agent workflow with branch-based development process
 - ✅ **TypeScript Configuration**: Monorepo setup with project references and proper compilation
-- 🔄 **Implementation Readiness**: Ready to begin Stage 1 development
+- ✅ **Implementation Readiness**: Stage 1 project setup underway with TypeScript references and pre-commit hooks
 
 ## Implementation Roadmap
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "build": "tsc -b",
-    "dev": "echo \"Dev server not implemented yet\""
+    "dev": "echo \"Dev server not implemented yet\"",
+    "prepare": "husky install"
   },
   "keywords": [],
   "author": "",
@@ -41,5 +42,11 @@
     "fastify": "^5.5.0",
     "pino": "^9.8.0",
     "pino-pretty": "^13.1.1"
+  },
+  "lint-staged": {
+    "*.{ts,js,json,md}": [
+      "prettier --write",
+      "eslint --fix"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- mark TypeScript project references and linting hooks as completed
- configure Husky pre-commit with lint-staged
- document project setup progress

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689dd620fd048321a68b8407f2103c0d