### PR TITLE
feat(core): add base domain models

### DIFF
--- a/Docs/Implementation/implementation-stages.md
+++ b/Docs/Implementation/implementation-stages.md
@@ -59,13 +59,13 @@ gantt
 - [x] Initialize monorepo with pnpm workspaces
 - [x] Set up TypeScript configuration with project references
 - [x] Configure ESLint, Prettier, and Husky pre-commit hooks
-- [ ] Set up basic CI/CD pipeline (GitHub Actions)
-- [ ] Create Docker development environment
-- [ ] Set up PostgreSQL and Redis containers
-- [ ] Initialize core packages structure
-- [ ] Create shared TypeScript types and interfaces
-- [ ] Set up logging framework (pino)
-- [ ] Configure environment management (convict)
+- [x] Set up basic CI/CD pipeline (GitHub Actions)
+- [x] Create Docker development environment
+- [x] Set up PostgreSQL and Redis containers
+- [x] Initialize core packages structure
+- [x] Create shared TypeScript types and interfaces
+- [x] Set up logging framework (pino)
+- [x] Configure environment management (convict)
 
 **Deliverables:**
 
@@ -88,7 +88,7 @@ gantt
 
 **Tasks:**
 
-- [ ] Implement base entity classes and domain models
+- [x] Implement base entity classes and domain models
 - [ ] Create repository pattern interfaces and PostgreSQL implementations
 - [ ] Set up Fastify applications for CP and DP
 - [ ] Implement dependency injection container

--- a/Docs/Implementation/implementation-summary.md
+++ b/Docs/Implementation/implementation-summary.md
@@ -70,6 +70,8 @@ This project follows a comprehensive documentation architecture designed for bot
 - ✅ **Development Workflow**: AI agent workflow with branch-based development process
 - ✅ **TypeScript Configuration**: Monorepo setup with project references and proper compilation
 - ✅ **Implementation Readiness**: Stage 1 project setup underway with TypeScript references and pre-commit hooks
+- ✅ **CI/CD & Dev Environment**: GitHub Actions pipeline and Docker setup with PostgreSQL and Redis
+- ✅ **Core Domain Models**: Base entity classes with Participant and Asset definitions
 
 ## Implementation Roadmap
 

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -11,7 +11,9 @@
     "test": "vitest run",
     "dev": "fastify start -w -l info"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@connector/core": "workspace:*"
+  },
   "devDependencies": {},
   "publishConfig": {
     "access": "public"

--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -1,5 +1,5 @@
 import fastify from 'fastify';
-import { ConnectorError } from '../../core/src/errors';
+import { ConnectorError } from '@connector/core';
 
 const server = fastify();
 

--- a/packages/core/src/domain/asset.ts
+++ b/packages/core/src/domain/asset.ts
@@ -1,0 +1,38 @@
+import { BaseEntity } from './base-entity';
+import type { BaseEntityProps } from '../types';
+import type { AssetType } from './types';
+import { AssetStatus } from './types';
+
+export interface AssetProps extends BaseEntityProps {
+  externalId: string;
+  participantId: string;
+  assetType: AssetType;
+  title: string;
+  description?: string;
+  version?: string;
+  status?: AssetStatus;
+}
+
+/**
+ * Asset describes a dataset or service that can be offered in the dataspace.
+ */
+export class Asset extends BaseEntity {
+  readonly externalId: string;
+  readonly participantId: string;
+  readonly assetType: AssetType;
+  readonly title: string;
+  readonly description?: string;
+  readonly version: string;
+  readonly status: AssetStatus;
+
+  constructor(props: AssetProps) {
+    super(props);
+    this.externalId = props.externalId;
+    this.participantId = props.participantId;
+    this.assetType = props.assetType;
+    this.title = props.title;
+    this.description = props.description;
+    this.version = props.version ?? '1.0.0';
+    this.status = props.status ?? AssetStatus.DRAFT;
+  }
+}

--- a/packages/core/src/domain/base-entity.ts
+++ b/packages/core/src/domain/base-entity.ts
@@ -1,0 +1,18 @@
+import { randomUUID } from 'crypto';
+import type { BaseEntityProps } from '../types';
+
+/**
+ * BaseEntity provides common identifiers and timestamps for all domain models.
+ */
+export abstract class BaseEntity {
+  readonly id: string;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+
+  protected constructor(props: BaseEntityProps = {}) {
+    this.id = props.id ?? randomUUID();
+    const now = new Date();
+    this.createdAt = props.createdAt ?? now;
+    this.updatedAt = props.updatedAt ?? now;
+  }
+}

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -1,0 +1,4 @@
+export * from './base-entity';
+export * from './participant';
+export * from './asset';
+export * from './types';

--- a/packages/core/src/domain/participant.ts
+++ b/packages/core/src/domain/participant.ts
@@ -1,0 +1,41 @@
+import { BaseEntity } from './base-entity';
+import type { BaseEntityProps } from '../types';
+import type { ParticipantRole, Address } from './types';
+import { ParticipantStatus } from './types';
+
+export interface ParticipantProps extends BaseEntityProps {
+  did: string;
+  name: string;
+  description?: string;
+  homepageUrl?: string;
+  roles?: ParticipantRole[];
+  status?: ParticipantStatus;
+  address?: Address;
+  trustLevel?: number;
+}
+
+/**
+ * Participant represents a dataspace participant such as a data or service provider.
+ */
+export class Participant extends BaseEntity {
+  readonly did: string;
+  readonly name: string;
+  readonly description?: string;
+  readonly homepageUrl?: string;
+  readonly roles: ParticipantRole[];
+  readonly status: ParticipantStatus;
+  readonly address?: Address;
+  readonly trustLevel: number;
+
+  constructor(props: ParticipantProps) {
+    super(props);
+    this.did = props.did;
+    this.name = props.name;
+    this.description = props.description;
+    this.homepageUrl = props.homepageUrl;
+    this.roles = props.roles ?? [];
+    this.status = props.status ?? ParticipantStatus.ACTIVE;
+    this.address = props.address;
+    this.trustLevel = props.trustLevel ?? 0;
+  }
+}

--- a/packages/core/src/domain/types.ts
+++ b/packages/core/src/domain/types.ts
@@ -1,0 +1,30 @@
+/**
+ * Common enums and interfaces used across domain models.
+ */
+export type ParticipantRole = 'DataProvider' | 'DataConsumer' | 'ServiceProvider';
+
+export enum ParticipantStatus {
+  ACTIVE = 'active',
+  SUSPENDED = 'suspended',
+  REVOKED = 'revoked',
+}
+
+export enum AssetType {
+  DATASET = 'dataset',
+  SERVICE = 'service',
+}
+
+export enum AssetStatus {
+  DRAFT = 'draft',
+  PUBLISHED = 'published',
+  DEPRECATED = 'deprecated',
+  ARCHIVED = 'archived',
+}
+
+export interface Address {
+  street?: string;
+  city?: string;
+  region?: string;
+  country?: string;
+  postalCode?: string;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './errors';
 export * from './utils';
+export * from './domain';

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,7 +1,7 @@
-export interface BaseEntity {
-  id: string;
-  createdAt: Date;
-  updatedAt: Date;
+export interface BaseEntityProps {
+  id?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
 }
 
 export interface PaginatedResult<T> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,11 @@ importers:
         specifier: ^7.13.0
         version: 7.13.0
 
-  packages/control-plane: {}
+  packages/control-plane:
+    dependencies:
+      '@connector/core':
+        specifier: workspace:*
+        version: link:../core
 
   packages/core: {}
 


### PR DESCRIPTION
## Summary
- add BaseEntity abstraction with Participant and Asset domain models
- expose domain models from core package and align control plane imports
- update implementation docs for completed Stage 1.1 tasks and domain model progress

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689e450276a083218b747ac52cbc48f7