### PR TITLE
feat(core): add repository layer with postgres implementation

### DIFF
--- a/Docs/Implementation/implementation-stages.md
+++ b/Docs/Implementation/implementation-stages.md
@@ -89,7 +89,7 @@ gantt
 **Tasks:**
 
 - [x] Implement base entity classes and domain models
-- [ ] Create repository pattern interfaces and PostgreSQL implementations
+- [x] Create repository pattern interfaces and PostgreSQL implementations
 - [ ] Set up Fastify applications for CP and DP
 - [ ] Implement dependency injection container
 - [ ] Create event bus for internal communication

--- a/Docs/Implementation/implementation-summary.md
+++ b/Docs/Implementation/implementation-summary.md
@@ -72,6 +72,7 @@ This project follows a comprehensive documentation architecture designed for bot
 - ✅ **Implementation Readiness**: Stage 1 project setup underway with TypeScript references and pre-commit hooks
 - ✅ **CI/CD & Dev Environment**: GitHub Actions pipeline and Docker setup with PostgreSQL and Redis
 - ✅ **Core Domain Models**: Base entity classes with Participant and Asset definitions
+- ✅ **Repository Layer**: Interfaces and PostgreSQL implementations for core entities
 
 ## Implementation Roadmap
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,9 +10,13 @@
     "lint": "eslint . --ext .ts",
     "test": "vitest run"
   },
-  "dependencies": {},
-  "devDependencies": {},
+  "dependencies": {
+    "pg": "^8.16.3"
+  },
   "publishConfig": {
     "access": "public"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.15.5"
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export * from './errors';
 export * from './utils';
 export * from './domain';
+export * from './repositories';

--- a/packages/core/src/repositories/asset-repository.ts
+++ b/packages/core/src/repositories/asset-repository.ts
@@ -1,0 +1,4 @@
+import type { Asset } from '../domain/asset';
+import type { Repository } from './base';
+
+export type AssetRepository = Repository<Asset>;

--- a/packages/core/src/repositories/base.ts
+++ b/packages/core/src/repositories/base.ts
@@ -1,0 +1,7 @@
+export interface Repository<T> {
+  findById(id: string): Promise<T | null>;
+  findAll(): Promise<T[]>;
+  create(entity: T): Promise<T>;
+  update(entity: T): Promise<T>;
+  delete(id: string): Promise<void>;
+}

--- a/packages/core/src/repositories/index.ts
+++ b/packages/core/src/repositories/index.ts
@@ -1,0 +1,5 @@
+export * from './base';
+export * from './participant-repository';
+export * from './asset-repository';
+export * from './postgres/postgres-participant-repository';
+export * from './postgres/postgres-asset-repository';

--- a/packages/core/src/repositories/participant-repository.ts
+++ b/packages/core/src/repositories/participant-repository.ts
@@ -1,0 +1,4 @@
+import type { Participant } from '../domain/participant';
+import type { Repository } from './base';
+
+export type ParticipantRepository = Repository<Participant>;

--- a/packages/core/src/repositories/postgres/postgres-asset-repository.ts
+++ b/packages/core/src/repositories/postgres/postgres-asset-repository.ts
@@ -1,0 +1,92 @@
+import type { Pool } from 'pg';
+import { Asset } from '../../domain/asset';
+import type { AssetStatus, AssetType } from '../../domain/types';
+import type { AssetRepository } from '../asset-repository';
+
+type AssetRow = {
+  id: string;
+  created_at: Date;
+  updated_at: Date;
+  external_id: string;
+  participant_id: string;
+  asset_type: string;
+  title: string;
+  description: string | null;
+  version: string;
+  status: string;
+};
+
+export class PostgresAssetRepository implements AssetRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async findById(id: string): Promise<Asset | null> {
+    const result = await this.pool.query('SELECT * FROM assets WHERE id = $1', [id]);
+    if (result.rows.length === 0) {
+      return null;
+    }
+    return this.mapRow(result.rows[0]);
+  }
+
+  async findAll(): Promise<Asset[]> {
+    const result = await this.pool.query('SELECT * FROM assets');
+    return result.rows.map((row: AssetRow) => this.mapRow(row));
+  }
+
+  async create(entity: Asset): Promise<Asset> {
+    const result = await this.pool.query(
+      `INSERT INTO assets (id, external_id, participant_id, asset_type, title, description, version, status, created_at, updated_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) RETURNING *`,
+      [
+        entity.id,
+        entity.externalId,
+        entity.participantId,
+        entity.assetType,
+        entity.title,
+        entity.description ?? null,
+        entity.version,
+        entity.status,
+        entity.createdAt,
+        entity.updatedAt,
+      ]
+    );
+    return this.mapRow(result.rows[0]);
+  }
+
+  async update(entity: Asset): Promise<Asset> {
+    const result = await this.pool.query(
+      `UPDATE assets SET external_id=$2, participant_id=$3, asset_type=$4, title=$5, description=$6, version=$7, status=$8, updated_at=$9
+       WHERE id=$1 RETURNING *`,
+      [
+        entity.id,
+        entity.externalId,
+        entity.participantId,
+        entity.assetType,
+        entity.title,
+        entity.description ?? null,
+        entity.version,
+        entity.status,
+        entity.updatedAt,
+      ]
+    );
+    return this.mapRow(result.rows[0]);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.pool.query('DELETE FROM assets WHERE id=$1', [id]);
+  }
+
+  private mapRow(row: AssetRow): Asset {
+    return new Asset({
+      id: row.id,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      externalId: row.external_id,
+      participantId: row.participant_id,
+      assetType: row.asset_type as AssetType,
+      title: row.title,
+      description: row.description ?? undefined,
+      version: row.version,
+      status: row.status as AssetStatus,
+    });
+  }
+}

--- a/packages/core/src/repositories/postgres/postgres-participant-repository.ts
+++ b/packages/core/src/repositories/postgres/postgres-participant-repository.ts
@@ -1,0 +1,96 @@
+import type { Pool } from 'pg';
+import { Participant } from '../../domain/participant';
+import type { ParticipantStatus } from '../../domain/types';
+import type { ParticipantRepository } from '../participant-repository';
+
+type ParticipantRow = {
+  id: string;
+  created_at: Date;
+  updated_at: Date;
+  did: string;
+  name: string;
+  description: string | null;
+  homepage_url: string | null;
+  roles: string[] | null;
+  status: string;
+  address: string | null;
+  trust_level: number | null;
+};
+
+export class PostgresParticipantRepository implements ParticipantRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async findById(id: string): Promise<Participant | null> {
+    const result = await this.pool.query('SELECT * FROM participants WHERE id = $1', [id]);
+    if (result.rows.length === 0) {
+      return null;
+    }
+    return this.mapRow(result.rows[0]);
+  }
+
+  async findAll(): Promise<Participant[]> {
+    const result = await this.pool.query('SELECT * FROM participants');
+    return result.rows.map((row: ParticipantRow) => this.mapRow(row));
+  }
+
+  async create(entity: Participant): Promise<Participant> {
+    const result = await this.pool.query(
+      `INSERT INTO participants (id, did, name, description, homepage_url, roles, status, address, trust_level, created_at, updated_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11) RETURNING *`,
+      [
+        entity.id,
+        entity.did,
+        entity.name,
+        entity.description ?? null,
+        entity.homepageUrl ?? null,
+        entity.roles,
+        entity.status,
+        entity.address ? JSON.stringify(entity.address) : null,
+        entity.trustLevel,
+        entity.createdAt,
+        entity.updatedAt,
+      ]
+    );
+    return this.mapRow(result.rows[0]);
+  }
+
+  async update(entity: Participant): Promise<Participant> {
+    const result = await this.pool.query(
+      `UPDATE participants SET did=$2, name=$3, description=$4, homepage_url=$5, roles=$6, status=$7, address=$8, trust_level=$9, updated_at=$10
+       WHERE id=$1 RETURNING *`,
+      [
+        entity.id,
+        entity.did,
+        entity.name,
+        entity.description ?? null,
+        entity.homepageUrl ?? null,
+        entity.roles,
+        entity.status,
+        entity.address ? JSON.stringify(entity.address) : null,
+        entity.trustLevel,
+        entity.updatedAt,
+      ]
+    );
+    return this.mapRow(result.rows[0]);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.pool.query('DELETE FROM participants WHERE id=$1', [id]);
+  }
+
+  private mapRow(row: ParticipantRow): Participant {
+    return new Participant({
+      id: row.id,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      did: row.did,
+      name: row.name,
+      description: row.description ?? undefined,
+      homepageUrl: row.homepage_url ?? undefined,
+      roles: row.roles ?? [],
+      status: row.status as ParticipantStatus,
+      address: row.address ? JSON.parse(row.address) : undefined,
+      trustLevel: row.trust_level ?? 0,
+    });
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,15 @@ importers:
         specifier: workspace:*
         version: link:../core
 
-  packages/core: {}
+  packages/core:
+    dependencies:
+      pg:
+        specifier: ^8.16.3
+        version: 8.16.3
+    devDependencies:
+      '@types/pg':
+        specifier: ^8.15.5
+        version: 8.15.5
 
   packages/data-plane: {}
 
@@ -198,6 +206,9 @@ packages:
 
   '@types/node@24.2.1':
     resolution: {integrity: sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==}
+
+  '@types/pg@8.15.5':
+    resolution: {integrity: sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==}
 
   '@typescript-eslint/eslint-plugin@8.39.1':
     resolution: {integrity: sha512-yYegZ5n3Yr6eOcqgj2nJH8cH/ZZgF+l0YIdKILSDjYFRjgYQMgv/lRjV5Z7Up04b9VYUondt8EPMqg7kTWgJ2g==}
@@ -1072,6 +1083,40 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+  pg-cloudflare@1.2.7:
+    resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
+
+  pg-connection-string@2.9.1:
+    resolution: {integrity: sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.10.1:
+    resolution: {integrity: sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.10.3:
+    resolution: {integrity: sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.16.3:
+    resolution: {integrity: sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -1098,6 +1143,22 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.0:
+    resolution: {integrity: sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -1412,6 +1473,10 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   yaml@2.8.1:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
     engines: {node: '>= 14.6'}
@@ -1536,6 +1601,12 @@ snapshots:
   '@types/node@24.2.1':
     dependencies:
       undici-types: 7.10.0
+
+  '@types/pg@8.15.5':
+    dependencies:
+      '@types/node': 24.2.1
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
 
   '@typescript-eslint/eslint-plugin@8.39.1(@typescript-eslint/parser@8.39.1(eslint@9.33.0)(typescript@5.9.2))(eslint@9.33.0)(typescript@5.9.2)':
     dependencies:
@@ -2576,6 +2647,41 @@ snapshots:
 
   path-parse@1.0.7: {}
 
+  pg-cloudflare@1.2.7:
+    optional: true
+
+  pg-connection-string@2.9.1: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.10.1(pg@8.16.3):
+    dependencies:
+      pg: 8.16.3
+
+  pg-protocol@1.10.3: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.0
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.16.3:
+    dependencies:
+      pg-connection-string: 2.9.1
+      pg-pool: 3.10.1(pg@8.16.3)
+      pg-protocol: 1.10.3
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.2.7
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picomatch@2.3.1: {}
 
   pidtree@0.6.0: {}
@@ -2617,6 +2723,16 @@ snapshots:
       thread-stream: 3.1.0
 
   possible-typed-array-names@1.1.0: {}
+
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.0: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
 
@@ -2991,6 +3107,8 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
+
+  xtend@4.0.2: {}
 
   yaml@2.8.1: {}
 


### PR DESCRIPTION
## Summary
- add generic repository interface and typed repositories for Participants and Assets
- implement PostgreSQL repositories using pg
- document completion of repository layer in implementation docs

## Testing
- `pnpm build`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689e58f3e0b88321bc687cc0a39978ea