### PR TITLE
style(core): format postgres repositories

### DIFF
--- a/packages/core/src/repositories/postgres/postgres-asset-repository.ts
+++ b/packages/core/src/repositories/postgres/postgres-asset-repository.ts
@@ -47,7 +47,7 @@ export class PostgresAssetRepository implements AssetRepository {
         entity.status,
         entity.createdAt,
         entity.updatedAt,
-      ]
+      ],
     );
     return this.mapRow(result.rows[0]);
   }
@@ -66,7 +66,7 @@ export class PostgresAssetRepository implements AssetRepository {
         entity.version,
         entity.status,
         entity.updatedAt,
-      ]
+      ],
     );
     return this.mapRow(result.rows[0]);
   }

--- a/packages/core/src/repositories/postgres/postgres-participant-repository.ts
+++ b/packages/core/src/repositories/postgres/postgres-participant-repository.ts
@@ -49,7 +49,7 @@ export class PostgresParticipantRepository implements ParticipantRepository {
         entity.trustLevel,
         entity.createdAt,
         entity.updatedAt,
-      ]
+      ],
     );
     return this.mapRow(result.rows[0]);
   }
@@ -69,7 +69,7 @@ export class PostgresParticipantRepository implements ParticipantRepository {
         entity.address ? JSON.stringify(entity.address) : null,
         entity.trustLevel,
         entity.updatedAt,
-      ]
+      ],
     );
     return this.mapRow(result.rows[0]);
   }


### PR DESCRIPTION
## Summary
- fix prettier errors in Postgres asset and participant repositories by adding trailing commas

## Testing
- `pnpm format:check`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689ec197a41c8321b641d82fcc754d0e