### PR TITLE
Fix participant roles mapping and control-plane error handling

### DIFF
--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -1,5 +1,5 @@
 import fastify from 'fastify';
-import { ConnectorError } from '@connector/core';
+import { ConnectorError } from '../../core/src/errors';
 
 const server = fastify();
 
@@ -9,9 +9,10 @@ server.get('/health', async () => {
 
 server.setErrorHandler((error, request, reply) => {
   if (error instanceof ConnectorError) {
-    reply.status(error.statusCode).send({
-      error: error.errorCode,
-      message: error.message,
+    const connectorError = error as ConnectorError;
+    reply.status(connectorError.statusCode).send({
+      error: connectorError.errorCode,
+      message: connectorError.message,
     });
   } else {
     reply.status(500).send({

--- a/packages/core/src/repositories/postgres/postgres-participant-repository.ts
+++ b/packages/core/src/repositories/postgres/postgres-participant-repository.ts
@@ -1,6 +1,6 @@
 import type { Pool } from 'pg';
 import { Participant } from '../../domain/participant';
-import type { ParticipantStatus } from '../../domain/types';
+import type { ParticipantRole, ParticipantStatus } from '../../domain/types';
 import type { ParticipantRepository } from '../participant-repository';
 
 type ParticipantRow = {
@@ -87,7 +87,7 @@ export class PostgresParticipantRepository implements ParticipantRepository {
       name: row.name,
       description: row.description ?? undefined,
       homepageUrl: row.homepage_url ?? undefined,
-      roles: row.roles ?? [],
+      roles: row.roles?.map((role) => role as ParticipantRole) ?? [],
       status: row.status as ParticipantStatus,
       address: row.address ? JSON.parse(row.address) : undefined,
       trustLevel: row.trust_level ?? 0,


### PR DESCRIPTION
## Summary
- correctly type-cast Postgres participant roles
- improve control-plane error handler and use local core import

## Testing
- `pnpm build`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689edaf271d883218871a1ed26807346