### PR TITLE
feat: add internal event bus

### DIFF
--- a/Docs/Implementation/implementation-stages.md
+++ b/Docs/Implementation/implementation-stages.md
@@ -92,7 +92,7 @@ gantt
 - [x] Create repository pattern interfaces and PostgreSQL implementations
 - [x] Set up Fastify applications for CP and DP
 - [x] Implement dependency injection container
-- [ ] Create event bus for internal communication
+- [x] Create event bus for internal communication
 - [ ] Set up database migrations with Prisma
 - [ ] Implement configuration management
 - [ ] Create error handling middleware

--- a/Docs/Implementation/implementation-summary.md
+++ b/Docs/Implementation/implementation-summary.md
@@ -75,6 +75,7 @@ This project follows a comprehensive documentation architecture designed for bot
 - ✅ **Repository Layer**: Interfaces and PostgreSQL implementations for core entities
 - ✅ **Fastify Applications**: Shared Fastify setup for Control and Data Planes with health endpoints
 - ✅ **Dependency Injection Container**: Lightweight service registration and resolution
+- ✅ **Event Bus**: Simple publish/subscribe mechanism for internal communication
 
 ## Implementation Roadmap
 

--- a/packages/shared/src/event-bus/index.ts
+++ b/packages/shared/src/event-bus/index.ts
@@ -1,0 +1,55 @@
+/**
+ * Simple asynchronous event bus for internal communication.
+ * Provides typed publish/subscribe functionality without
+ * external dependencies.
+ */
+export type EventHandler<T> = (payload: T) => void | Promise<void>;
+
+export class EventBus<Events extends Record<string, unknown>> {
+  private readonly handlers: Map<keyof Events, Set<EventHandler<Events[keyof Events]>>> = new Map();
+
+  /**
+   * Subscribe to a specific event.
+   * @param event Event name to subscribe to.
+   * @param handler Handler invoked when the event is published.
+   */
+  on<K extends keyof Events>(event: K, handler: EventHandler<Events[K]>): void {
+    const existing = (this.handlers.get(event) as Set<EventHandler<Events[K]>> | undefined) ?? new Set();
+    existing.add(handler);
+    this.handlers.set(event, existing as Set<EventHandler<Events[keyof Events]>>);
+  }
+
+  /**
+   * Unsubscribe a handler from an event.
+   * @param event Event name to unsubscribe from.
+   * @param handler Handler to remove.
+   */
+  off<K extends keyof Events>(event: K, handler: EventHandler<Events[K]>): void {
+    const set = this.handlers.get(event) as Set<EventHandler<Events[K]>> | undefined;
+    set?.delete(handler);
+    if (set && set.size === 0) {
+      this.handlers.delete(event);
+    }
+  }
+
+  /**
+   * Publish an event with a payload.
+   * Handlers are invoked sequentially and awaited if they return a Promise.
+   * @param event Event name to publish.
+   * @param payload Event payload.
+   */
+  async emit<K extends keyof Events>(event: K, payload: Events[K]): Promise<void> {
+    const set = this.handlers.get(event) as Set<EventHandler<Events[K]>> | undefined;
+    if (!set) return;
+    for (const handler of Array.from(set)) {
+      await handler(payload);
+    }
+  }
+
+  /**
+   * Remove all handlers. Useful for testing.
+   */
+  clear(): void {
+    this.handlers.clear();
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from './config';
 export * from './logger';
 export * from './container';
+export * from './event-bus';


### PR DESCRIPTION
## Summary
- implement lightweight asynchronous event bus for intra-service communication
- expose event bus through shared package
- document event bus completion in implementation docs

## Testing
- `pnpm --filter @connector/shared build`
- `pnpm build`
- `pnpm test`
- `pnpm lint` *(fails: Cannot find module '@typescript-eslint/typescript-estree')*

------
https://chatgpt.com/codex/tasks/task_e_689fae7c24808321bb0d26714dc6b013