### PR TITLE
feat: implement configuration management

### DIFF
--- a/Docs/Implementation/implementation-stages.md
+++ b/Docs/Implementation/implementation-stages.md
@@ -94,7 +94,7 @@ gantt
 - [x] Implement dependency injection container
 - [x] Create event bus for internal communication
 - [x] Set up database migrations with Prisma
-- [ ] Implement configuration management
+- [x] Implement configuration management
 - [ ] Create error handling middleware
 - [ ] Set up request/response validation with JSON Schema
 - [ ] Implement basic health check and readiness endpoints

--- a/Docs/Implementation/implementation-summary.md
+++ b/Docs/Implementation/implementation-summary.md
@@ -77,6 +77,7 @@ This project follows a comprehensive documentation architecture designed for bot
 - ✅ **Dependency Injection Container**: Lightweight service registration and resolution
 - ✅ **Event Bus**: Simple publish/subscribe mechanism for internal communication
 - ✅ **Database Migrations**: Prisma schema and initial migration for core entities
+- ✅ **Configuration Management**: Centralized environment configuration via Convict
 
 ## Implementation Roadmap
 

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -12,7 +12,8 @@
     "dev": "fastify start -w -l info"
   },
   "dependencies": {
-    "@connector/core": "workspace:*"
+    "@connector/core": "workspace:*",
+    "@connector/shared": "workspace:*"
   },
   "devDependencies": {},
   "publishConfig": {

--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -1,11 +1,12 @@
 import { createServer } from '@connector/core';
+import { config } from '@connector/shared';
 
 /**
  * Bootstraps and starts the Control Plane Fastify server.
  */
 export async function start(): Promise<void> {
   const server = createServer();
-  const port = Number(process.env.CP_PORT) || 3000;
+  const port = config.get('controlPlane.port');
 
   try {
     await server.listen({ port, host: '0.0.0.0' });

--- a/packages/data-plane/package.json
+++ b/packages/data-plane/package.json
@@ -12,7 +12,8 @@
     "dev": "fastify start -w -l info"
   },
   "dependencies": {
-    "@connector/core": "workspace:*"
+    "@connector/core": "workspace:*",
+    "@connector/shared": "workspace:*"
   },
   "devDependencies": {},
   "publishConfig": {

--- a/packages/data-plane/src/index.ts
+++ b/packages/data-plane/src/index.ts
@@ -1,11 +1,12 @@
 import { createServer } from '@connector/core';
+import { config } from '@connector/shared';
 
 /**
  * Bootstraps and starts the Data Plane Fastify server.
  */
 export async function start(): Promise<void> {
   const server = createServer();
-  const port = Number(process.env.DP_PORT) || 3001;
+  const port = config.get('dataPlane.port');
 
   try {
     await server.listen({ port, host: '0.0.0.0' });

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -1,32 +1,65 @@
 import convict from 'convict';
+import type { Schema } from 'convict';
 
-const config = convict({
+interface AppConfig {
+  env: 'production' | 'development' | 'test';
+  controlPlane: {
+    port: number;
+  };
+  dataPlane: {
+    port: number;
+  };
+  database: {
+    url: string;
+  };
+  redis: {
+    url: string;
+  };
+}
+
+const schema: Schema<AppConfig> = {
   env: {
     doc: 'The application environment.',
     format: ['production', 'development', 'test'],
     default: 'development',
     env: 'NODE_ENV',
   },
-  port: {
-    doc: 'The port to bind.',
-    format: 'port',
-    default: 3000,
-    env: 'PORT',
+  controlPlane: {
+    port: {
+      doc: 'The port for the control plane.',
+      format: 'port',
+      default: 3000,
+      env: 'CP_PORT',
+    },
   },
-  databaseUrl: {
-    doc: 'The database connection URL.',
-    format: String,
-    default: 'postgresql://connector:connector@localhost:5432/connector',
-    env: 'DATABASE_URL',
+  dataPlane: {
+    port: {
+      doc: 'The port for the data plane.',
+      format: 'port',
+      default: 3001,
+      env: 'DP_PORT',
+    },
   },
-  redisUrl: {
-    doc: 'The Redis connection URL.',
-    format: String,
-    default: 'redis://localhost:6379',
-    env: 'REDIS_URL',
+  database: {
+    url: {
+      doc: 'The database connection URL.',
+      format: String,
+      default: 'postgresql://connector:connector@localhost:5432/connector',
+      env: 'DATABASE_URL',
+    },
   },
-});
+  redis: {
+    url: {
+      doc: 'The Redis connection URL.',
+      format: String,
+      default: 'redis://localhost:6379',
+      env: 'REDIS_URL',
+    },
+  },
+};
 
+const config = convict<AppConfig>(schema);
 config.validate({ allowed: 'strict' });
 
 export default config;
+export type { AppConfig };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,4 @@
-export * from './config';
+export { default as config } from './config';
 export * from './logger';
 export * from './container';
 export * from './event-bus';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@connector/core':
         specifier: workspace:*
         version: link:../core
+      '@connector/shared':
+        specifier: workspace:*
+        version: link:../shared
 
   packages/core:
     dependencies:
@@ -100,6 +103,9 @@ importers:
       '@connector/core':
         specifier: workspace:*
         version: link:../core
+      '@connector/shared':
+        specifier: workspace:*
+        version: link:../shared
 
   packages/shared: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
 packages:
-  - 'packages/*'
+  - packages/*
+
+onlyBuiltDependencies:
+  - '@prisma/client'
+  - '@prisma/engines'
+  - prisma


### PR DESCRIPTION
## Summary
- add central Convict-based config with control and data plane ports
- use shared config in control-plane and data-plane startup
- document configuration management completion

## Testing
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a03638d458832194af56e1dcce096d