### PR TITLE
chore: update lockfile for shared package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
       '@connector/core':
         specifier: workspace:*
         version: link:../core
+      '@connector/shared':
+        specifier: workspace:*
+        version: link:../shared
 
   packages/core:
     dependencies:
@@ -100,6 +103,9 @@ importers:
       '@connector/core':
         specifier: workspace:*
         version: link:../core
+      '@connector/shared':
+        specifier: workspace:*
+        version: link:../shared
 
   packages/shared: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
 packages:
-  - 'packages/*'
+  - packages/*
+
+onlyBuiltDependencies:
+  - '@prisma/client'
+  - '@prisma/engines'
+  - prisma


### PR DESCRIPTION
## Summary
- update `pnpm-lock.yaml` to include `@connector/shared`
- allow building prisma-related packages via `onlyBuiltDependencies`

## Testing
- `pnpm install --no-frozen-lockfile`
- `pnpm format`
- `pnpm lint`
- `pnpm build`
- `pnpm db:migrate` *(fails: Failed to fetch the engine file at https://binaries.prisma.sh/... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1808efb14832184f864af45dd4798