### PR TITLE
feat: add DSP message validation utility

### DIFF
--- a/Docs/Implementation/dsp-message-validation.md
+++ b/Docs/Implementation/dsp-message-validation.md
@@ -1,0 +1,25 @@
+# DSP Message Validation Usage
+
+This guide demonstrates how to validate a Dataspace Protocol (DSP) message using the shared validation utility.
+
+## Build the project
+
+```bash
+pnpm build
+```
+
+## Run a validation example
+
+```bash
+node -e "import { validateDspMessage } from './packages/core/dist/dsp/validator.js';
+const msg = { id: '123e4567-e89b-12d3-a456-426614174000', type: 'catalog:query', timestamp: new Date().toISOString(), issuer: 'did:web:example', data: {} };
+console.log(validateDspMessage(msg));"
+```
+
+**Expected output**
+
+```
+{ valid: true, errors: [] }
+```
+
+The validator returns `valid: false` with a list of error messages when the message does not conform to the schema.

--- a/Docs/Implementation/implementation-stages.md
+++ b/Docs/Implementation/implementation-stages.md
@@ -120,7 +120,7 @@ gantt
 
 **Tasks:**
 
-- [ ] Implement DSP message schemas and validation
+- [x] Implement DSP message schemas and validation
 - [ ] Create catalog endpoint with basic dataset/service listings
 - [ ] Implement contract negotiation state machine
 - [ ] Create negotiation endpoints (POST/GET /dsp/negotiations)

--- a/Docs/Implementation/implementation-summary.md
+++ b/Docs/Implementation/implementation-summary.md
@@ -78,6 +78,7 @@ This project follows a comprehensive documentation architecture designed for bot
 - ✅ **Event Bus**: Simple publish/subscribe mechanism for internal communication
 - ✅ **Database Migrations**: Prisma schema and initial migration for core entities
 - ✅ **Configuration Management**: Centralized environment configuration via Convict
+- ✅ **DSP Message Validation**: Common message envelope schema with AJV-based validation utility
 
 ## Implementation Roadmap
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "ajv": "^8.17.1",
     "pg": "^8.16.3"
   },
   "publishConfig": {

--- a/packages/core/src/dsp/index.ts
+++ b/packages/core/src/dsp/index.ts
@@ -1,0 +1,2 @@
+export * from './messages';
+export * from './validator';

--- a/packages/core/src/dsp/messages.ts
+++ b/packages/core/src/dsp/messages.ts
@@ -1,0 +1,32 @@
+import type { JSONSchema } from '../types';
+
+/**
+ * Basic DSP message envelope shared across all protocol messages.
+ * @template T payload type carried by the message
+ */
+export interface DspMessage<T = unknown> {
+  /** Unique message identifier */
+  id: string;
+  /** DSP message type, e.g. catalog:query */
+  type: string;
+  /** ISO-8601 timestamp when the message was created */
+  timestamp: string;
+  /** Identifier of the sending participant */
+  issuer: string;
+  /** Message payload */
+  data: T;
+}
+
+/** JSON Schema for the basic DSP message envelope */
+export const dspMessageSchema: JSONSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string', format: 'uuid' },
+    type: { type: 'string' },
+    timestamp: { type: 'string', format: 'date-time' },
+    issuer: { type: 'string' },
+    data: { type: 'object', additionalProperties: true },
+  },
+  required: ['id', 'type', 'timestamp', 'issuer', 'data'],
+  additionalProperties: false,
+};

--- a/packages/core/src/dsp/validator.ts
+++ b/packages/core/src/dsp/validator.ts
@@ -1,0 +1,26 @@
+import Ajv, { type ErrorObject } from 'ajv';
+import { dspMessageSchema } from './messages';
+
+const ajv = new Ajv({ allErrors: true });
+
+const validate = ajv.compile(dspMessageSchema);
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/**
+ * Validates a DSP message against the common envelope schema.
+ * @param message unknown message input
+ * @returns validation result with error details when invalid
+ */
+export function validateDspMessage(message: unknown): ValidationResult {
+  const valid = validate(message) as boolean;
+  const errors = (validate.errors || []).map(formatError);
+  return { valid, errors };
+}
+
+function formatError(error: ErrorObject): string {
+  return `${error.instancePath || '/'} ${error.message || ''}`.trim();
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,3 +3,4 @@ export * from './errors';
 export * from './utils';
 export * from './domain';
 export * from './repositories';
+export * from './dsp';

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -16,3 +16,16 @@ export interface ErrorResponse {
   error: string;
   message: string;
 }
+
+/**
+ * Minimal JSON Schema representation used across the project.
+ * This covers only the properties currently required by the
+ * connector and can be extended as needed.
+ */
+export interface JSONSchema {
+  type: string;
+  properties?: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean | JSONSchema;
+  [key: string]: unknown;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
 
   packages/core:
     dependencies:
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
       pg:
         specifier: ^8.16.3
         version: 8.16.3


### PR DESCRIPTION
## Summary
- add reusable DSP message envelope schema and validator
- document how to validate DSP messages
- track implementation progress for message validation task

## Testing
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a19c662b7c83218ff910cb03f99b3a