### PR TITLE
feat: add basic DSP catalog endpoint

### DIFF
--- a/Docs/Implementation/catalog-endpoint.md
+++ b/Docs/Implementation/catalog-endpoint.md
@@ -1,0 +1,48 @@
+# Catalog Endpoint Usage
+
+This guide demonstrates how to start the Control Plane and query the DSP catalog endpoint.
+
+## Start Control Plane
+
+```bash
+pnpm build
+node packages/control-plane/dist/index.js
+```
+
+The server listens on port `3000` by default.
+
+## Query Catalog
+
+```bash
+curl http://localhost:3000/dsp/catalog | jq
+```
+
+### Example Response
+
+```json
+{
+  "@context": "https://www.w3.org/ns/dcat2",
+  "@type": "dcat:Catalog",
+  "@id": "urn:connector:catalog",
+  "dcat:dataset": [
+    {
+      "@type": "dcat:Dataset",
+      "@id": "<dataset-id>",
+      "dct:title": "Sample Dataset",
+      "dct:description": "Example dataset asset"
+    }
+  ],
+  "dcat:service": [
+    {
+      "@type": "dcat:DataService",
+      "@id": "<service-id>",
+      "dct:title": "Sample Service",
+      "dct:description": "Example service asset",
+      "dcat:endpointURL": "https://example.com/service/1"
+    }
+  ],
+  "dct:conformsTo": "https://www.w3.org/TR/vocab-dcat-2/",
+  "dct:title": "Connector Catalog",
+  "dct:description": "Available assets and services"
+}
+```

--- a/Docs/Implementation/implementation-stages.md
+++ b/Docs/Implementation/implementation-stages.md
@@ -121,7 +121,7 @@ gantt
 **Tasks:**
 
 - [x] Implement DSP message schemas and validation
-- [ ] Create catalog endpoint with basic dataset/service listings
+- [x] Create catalog endpoint with basic dataset/service listings
 - [ ] Implement contract negotiation state machine
 - [ ] Create negotiation endpoints (POST/GET /dsp/negotiations)
 - [ ] Implement agreement endpoints (POST/GET /dsp/agreements)

--- a/Docs/Implementation/implementation-summary.md
+++ b/Docs/Implementation/implementation-summary.md
@@ -79,6 +79,7 @@ This project follows a comprehensive documentation architecture designed for bot
 - ✅ **Database Migrations**: Prisma schema and initial migration for core entities
 - ✅ **Configuration Management**: Centralized environment configuration via Convict
 - ✅ **DSP Message Validation**: Common message envelope schema with AJV-based validation utility
+- ✅ **Catalog Endpoint**: Basic dataset and service listings at `/dsp/catalog`
 
 ## Implementation Roadmap
 

--- a/packages/control-plane/src/index.ts
+++ b/packages/control-plane/src/index.ts
@@ -1,11 +1,46 @@
-import { createServer } from '@connector/core';
+import { createServer, Asset, AssetType, InMemoryAssetRepository } from '@connector/core';
 import { config } from '@connector/shared';
+import { registerCatalogRoutes } from './routes/catalog.js';
+import { randomUUID } from 'crypto';
 
 /**
  * Bootstraps and starts the Control Plane Fastify server.
  */
 export async function start(): Promise<void> {
   const server = createServer();
+
+  // Simple dependency setup
+  const assetRepo = new InMemoryAssetRepository();
+
+  // Seed example assets for demonstration
+  await assetRepo.create(
+    new Asset({
+      id: randomUUID(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      externalId: 'https://example.com/datasets/1',
+      participantId: 'urn:example:participant',
+      assetType: AssetType.DATASET,
+      title: 'Sample Dataset',
+      description: 'Example dataset asset',
+    }),
+  );
+
+  await assetRepo.create(
+    new Asset({
+      id: randomUUID(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      externalId: 'https://example.com/service/1',
+      participantId: 'urn:example:participant',
+      assetType: AssetType.SERVICE,
+      title: 'Sample Service',
+      description: 'Example service asset',
+    }),
+  );
+
+  registerCatalogRoutes(server, { assetRepo });
+
   const port = config.get('controlPlane.port');
 
   try {

--- a/packages/control-plane/src/routes/catalog.ts
+++ b/packages/control-plane/src/routes/catalog.ts
@@ -1,0 +1,56 @@
+import type { FastifyInstance } from 'fastify';
+import { AssetType, type AssetRepository } from '@connector/core';
+
+interface Deps {
+  assetRepo: AssetRepository;
+}
+
+/**
+ * Registers the DSP catalog endpoint.
+ * Returns basic dataset and service listings in JSON-LD format.
+ */
+export function registerCatalogRoutes(server: FastifyInstance, deps: Deps): void {
+  server.get(
+    '/dsp/catalog',
+    {
+      schema: {
+        response: {
+          200: { type: 'object', additionalProperties: true },
+        },
+      },
+    },
+    async () => {
+      const assets = await deps.assetRepo.findAll();
+
+      const datasets = assets
+        .filter(a => a.assetType === AssetType.DATASET)
+        .map(a => ({
+          '@type': 'dcat:Dataset',
+          '@id': a.id,
+          'dct:title': a.title,
+          'dct:description': a.description ?? '',
+        }));
+
+      const services = assets
+        .filter(a => a.assetType === AssetType.SERVICE)
+        .map(a => ({
+          '@type': 'dcat:DataService',
+          '@id': a.id,
+          'dct:title': a.title,
+          'dct:description': a.description ?? '',
+          'dcat:endpointURL': a.externalId,
+        }));
+
+      return {
+        '@context': 'https://www.w3.org/ns/dcat2',
+        '@type': 'dcat:Catalog',
+        '@id': 'urn:connector:catalog',
+        'dcat:dataset': datasets,
+        'dcat:service': services,
+        'dct:conformsTo': 'https://www.w3.org/TR/vocab-dcat-2/',
+        'dct:title': 'Connector Catalog',
+        'dct:description': 'Available assets and services',
+      };
+    },
+  );
+}

--- a/packages/core/src/repositories/index.ts
+++ b/packages/core/src/repositories/index.ts
@@ -3,3 +3,4 @@ export * from './participant-repository';
 export * from './asset-repository';
 export * from './postgres/postgres-participant-repository';
 export * from './postgres/postgres-asset-repository';
+export * from './memory/in-memory-asset-repository';

--- a/packages/core/src/repositories/memory/in-memory-asset-repository.ts
+++ b/packages/core/src/repositories/memory/in-memory-asset-repository.ts
@@ -1,0 +1,35 @@
+import type { Asset } from '../../domain/asset';
+import type { AssetRepository } from '../asset-repository';
+
+/**
+ * Simple in-memory Asset repository for early development and testing.
+ * Stores assets in a Map keyed by ID.
+ */
+export class InMemoryAssetRepository implements AssetRepository {
+  private readonly store = new Map<string, Asset>();
+
+  async findById(id: string): Promise<Asset | null> {
+    return this.store.get(id) ?? null;
+  }
+
+  async findAll(): Promise<Asset[]> {
+    return Array.from(this.store.values());
+  }
+
+  async create(entity: Asset): Promise<Asset> {
+    this.store.set(entity.id, entity);
+    return entity;
+  }
+
+  async update(entity: Asset): Promise<Asset> {
+    if (!this.store.has(entity.id)) {
+      throw new Error(`Asset with id ${entity.id} not found`);
+    }
+    this.store.set(entity.id, entity);
+    return entity;
+  }
+
+  async delete(id: string): Promise<void> {
+    this.store.delete(id);
+  }
+}


### PR DESCRIPTION
## Summary
- implement in-memory asset repository
- expose `/dsp/catalog` endpoint listing datasets and services
- document usage and mark stage progression

## Testing
- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d32e804c8321a18f88b0b9f58e0b