### PR TITLE
test: add repository and catalog tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "pnpm -r --workspace-root=false --filter @connector/core --filter @connector/shared test",
+    "test": "pnpm -r --workspace-root=false --filter @connector/core --filter @connector/shared --filter @connector/control-plane test",
     "lint": "eslint . --ext .ts,.js",
     "lint:fix": "eslint . --ext .ts,.js --fix",
     "format": "prettier --write .",

--- a/packages/control-plane/test/catalog.e2e.test.ts
+++ b/packages/control-plane/test/catalog.e2e.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { createServer, Asset, AssetType, InMemoryAssetRepository } from '../../core/src/index.js';
+import { registerCatalogRoutes } from '../src/routes/catalog.js';
+
+function setup() {
+  const server = createServer();
+  const repo = new InMemoryAssetRepository();
+  registerCatalogRoutes(server, { assetRepo: repo });
+  return { server, repo };
+}
+
+describe('catalog endpoint', () => {
+  it('returns datasets and services', async () => {
+    const { server, repo } = setup();
+    const dataset = new Asset({
+      id: 'dataset1',
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      updatedAt: new Date('2024-01-01T00:00:00Z'),
+      externalId: 'https://example.com/datasets/1',
+      participantId: 'p1',
+      assetType: AssetType.DATASET,
+      title: 'Dataset',
+      description: 'Example dataset',
+    });
+    const service = new Asset({
+      id: 'service1',
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      updatedAt: new Date('2024-01-01T00:00:00Z'),
+      externalId: 'https://example.com/services/1',
+      participantId: 'p1',
+      assetType: AssetType.SERVICE,
+      title: 'Service',
+      description: 'Example service',
+    });
+    await repo.create(dataset);
+    await repo.create(service);
+
+    const res = await server.inject({ method: 'GET', url: '/dsp/catalog' });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toMatchObject({
+      '@context': 'https://www.w3.org/ns/dcat2',
+      '@type': 'dcat:Catalog',
+      'dcat:dataset': [
+        {
+          '@type': 'dcat:Dataset',
+          '@id': dataset.id,
+          'dct:title': dataset.title,
+          'dct:description': dataset.description,
+        },
+      ],
+      'dcat:service': [
+        {
+          '@type': 'dcat:DataService',
+          '@id': service.id,
+          'dct:title': service.title,
+          'dct:description': service.description,
+          'dcat:endpointURL': service.externalId,
+        },
+      ],
+    });
+  });
+});

--- a/packages/core/test/in-memory-asset-repository.test.ts
+++ b/packages/core/test/in-memory-asset-repository.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { InMemoryAssetRepository } from '../src/repositories/memory/in-memory-asset-repository.js';
+import { Asset, AssetType } from '../src/domain/index.js';
+
+function createAsset(overrides: Partial<ConstructorParameters<typeof Asset>[0]> = {}) {
+  return new Asset({
+    id: 'asset1',
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    updatedAt: new Date('2024-01-01T00:00:00Z'),
+    externalId: 'ext-1',
+    participantId: 'participant',
+    assetType: AssetType.DATASET,
+    title: 'Test Asset',
+    description: 'desc',
+    ...overrides,
+  });
+}
+
+describe('InMemoryAssetRepository', () => {
+  it('creates and retrieves an asset', async () => {
+    const repo = new InMemoryAssetRepository();
+    const asset = createAsset();
+    await repo.create(asset);
+
+    await expect(repo.findById(asset.id)).resolves.toEqual(asset);
+    await expect(repo.findAll()).resolves.toEqual([asset]);
+  });
+
+  it('updates an existing asset', async () => {
+    const repo = new InMemoryAssetRepository();
+    const asset = createAsset();
+    await repo.create(asset);
+
+    const updated = createAsset({ id: asset.id, title: 'Updated' });
+    await repo.update(updated);
+
+    await expect(repo.findById(asset.id)).resolves.toEqual(updated);
+  });
+
+  it('throws when updating a missing asset', async () => {
+    const repo = new InMemoryAssetRepository();
+    const asset = createAsset();
+
+    await expect(repo.update(asset)).rejects.toThrow('Asset with id');
+  });
+
+  it('deletes an asset', async () => {
+    const repo = new InMemoryAssetRepository();
+    const asset = createAsset();
+    await repo.create(asset);
+
+    await repo.delete(asset.id);
+
+    await expect(repo.findById(asset.id)).resolves.toBeNull();
+    await expect(repo.findAll()).resolves.toEqual([]);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,4 @@
-import config from './config';
-
-export { config };
-export * from './logger';
-export * from './container';
-export * from './event-bus';
+export { default as config } from './config/index.js';
+export * from './logger/index.js';
+export * from './container/index.js';
+export * from './event-bus/index.js';


### PR DESCRIPTION
## Summary
- re-export shared config to fix build
- exercise in-memory asset repository with unit tests
- cover control-plane catalog route end-to-end and run tests in CI

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run build`
- `pnpm format:check`
- `pnpm install`
- `npm install` *(fails: Cannot read properties of null (reading 'matches'))*


------
https://chatgpt.com/codex/tasks/task_e_68a3780b1af08321a78e9a3472400239