### PR TITLE
feat: add contract negotiation state machine

### DIFF
--- a/Docs/Implementation/contract-negotiation-state-machine.md
+++ b/Docs/Implementation/contract-negotiation-state-machine.md
@@ -1,0 +1,57 @@
+# Contract Negotiation State Machine
+
+The connector now includes a standalone state machine that models the lifecycle of a DSP contract negotiation.
+It implements the progression from an initial request to a finalized or terminated agreement while guarding
+against invalid transitions.
+
+## Supported States
+
+`REQUESTED → OFFERED → ACCEPTED → AGREED → VERIFIED → FINALIZED`
+
+At any stage the negotiation may also transition to `TERMINATED`.
+
+## Trying It Out
+
+This feature is available via the `@connector/core` package and can be executed in a Node.js environment.
+
+### 1. Install dependencies
+
+```bash
+pnpm install
+```
+
+### 2. Run a demonstration script
+
+Create a file named `demo.ts` with the following content:
+
+```ts
+import { ContractNegotiation, NegotiationState } from '@connector/core';
+
+const negotiation = new ContractNegotiation();
+console.log(negotiation.state); // REQUESTED
+
+negotiation.transition(NegotiationState.OFFERED);
+negotiation.transition(NegotiationState.ACCEPTED);
+console.log(negotiation.state); // ACCEPTED
+```
+
+Execute the script with:
+
+```bash
+pnpm ts-node demo.ts
+```
+
+You should see:
+
+```
+REQUESTED
+ACCEPTED
+```
+
+Invalid transitions throw an error:
+
+```ts
+negotiation.transition(NegotiationState.FINALIZED); // throws
+```
+
+This state machine will be used by upcoming negotiation endpoints to manage DSP contract lifecycles.

--- a/Docs/Implementation/implementation-stages.md
+++ b/Docs/Implementation/implementation-stages.md
@@ -122,7 +122,7 @@ gantt
 
 - [x] Implement DSP message schemas and validation
 - [x] Create catalog endpoint with basic dataset/service listings
-- [ ] Implement contract negotiation state machine
+- [x] Implement contract negotiation state machine
 - [ ] Create negotiation endpoints (POST/GET /dsp/negotiations)
 - [ ] Implement agreement endpoints (POST/GET /dsp/agreements)
 - [ ] Create transfer process endpoints (POST/GET /dsp/transfers)

--- a/Docs/Implementation/implementation-summary.md
+++ b/Docs/Implementation/implementation-summary.md
@@ -80,6 +80,7 @@ This project follows a comprehensive documentation architecture designed for bot
 - ✅ **Configuration Management**: Centralized environment configuration via Convict
 - ✅ **DSP Message Validation**: Common message envelope schema with AJV-based validation utility
 - ✅ **Catalog Endpoint**: Basic dataset and service listings at `/dsp/catalog`
+- ✅ **Contract Negotiation State Machine**: Lifecycle management with guarded state transitions
 
 ## Implementation Roadmap
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,3 +4,4 @@ export * from './utils';
 export * from './domain';
 export * from './repositories';
 export * from './dsp';
+export * from './state-machine';

--- a/packages/core/src/state-machine/index.ts
+++ b/packages/core/src/state-machine/index.ts
@@ -1,0 +1,1 @@
+export * from './negotiation.state-machine';

--- a/packages/core/src/state-machine/negotiation.state-machine.ts
+++ b/packages/core/src/state-machine/negotiation.state-machine.ts
@@ -1,0 +1,76 @@
+import { BaseEntity } from '../domain/base-entity';
+import type { BaseEntityProps } from '../types';
+
+/**
+ * All possible states for a DSP contract negotiation.
+ */
+export enum NegotiationState {
+  REQUESTED = 'REQUESTED',
+  OFFERED = 'OFFERED',
+  ACCEPTED = 'ACCEPTED',
+  AGREED = 'AGREED',
+  VERIFIED = 'VERIFIED',
+  FINALIZED = 'FINALIZED',
+  TERMINATED = 'TERMINATED',
+}
+
+/**
+ * Allowed state transitions for contract negotiations as defined by DSP.
+ */
+const ALLOWED_TRANSITIONS: Record<NegotiationState, NegotiationState[]> = {
+  [NegotiationState.REQUESTED]: [NegotiationState.OFFERED, NegotiationState.TERMINATED],
+  [NegotiationState.OFFERED]: [NegotiationState.ACCEPTED, NegotiationState.TERMINATED],
+  [NegotiationState.ACCEPTED]: [
+    NegotiationState.AGREED,
+    NegotiationState.OFFERED,
+    NegotiationState.TERMINATED,
+  ],
+  [NegotiationState.AGREED]: [NegotiationState.VERIFIED, NegotiationState.TERMINATED],
+  [NegotiationState.VERIFIED]: [NegotiationState.FINALIZED, NegotiationState.TERMINATED],
+  [NegotiationState.FINALIZED]: [],
+  [NegotiationState.TERMINATED]: [],
+};
+
+export interface NegotiationProps extends BaseEntityProps {
+  state?: NegotiationState;
+}
+
+/**
+ * Simple state machine representing the lifecycle of a contract negotiation.
+ *
+ * The machine starts in the `REQUESTED` state and only allows transitions
+ * defined by the DSP specification. Invalid transitions throw an error.
+ */
+export class ContractNegotiation extends BaseEntity {
+  private _state: NegotiationState;
+
+  constructor(props: NegotiationProps = {}) {
+    super(props);
+    this._state = props.state ?? NegotiationState.REQUESTED;
+  }
+
+  /** Returns the current negotiation state. */
+  get state(): NegotiationState {
+    return this._state;
+  }
+
+  /**
+   * Attempts to transition the negotiation to a new state.
+   * @param newState desired target state
+   * @throws Error when the transition is not allowed
+   */
+  transition(newState: NegotiationState): void {
+    const allowed = ALLOWED_TRANSITIONS[this._state];
+    if (!allowed.includes(newState)) {
+      throw new Error(`Invalid transition from ${this._state} to ${newState}`);
+    }
+    this._state = newState;
+  }
+}
+
+/**
+ * Utility function to verify if a transition between two states is allowed.
+ */
+export function canTransition(from: NegotiationState, to: NegotiationState): boolean {
+  return ALLOWED_TRANSITIONS[from]?.includes(to) ?? false;
+}

--- a/packages/core/test/contract-negotiation-state-machine.test.ts
+++ b/packages/core/test/contract-negotiation-state-machine.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ContractNegotiation,
+  NegotiationState,
+  canTransition,
+} from '../src/state-machine/negotiation.state-machine.js';
+
+describe('ContractNegotiation state machine', () => {
+  it('starts in REQUESTED state by default', () => {
+    const negotiation = new ContractNegotiation();
+    expect(negotiation.state).toBe(NegotiationState.REQUESTED);
+  });
+
+  it('transitions through valid states', () => {
+    const negotiation = new ContractNegotiation();
+    negotiation.transition(NegotiationState.OFFERED);
+    negotiation.transition(NegotiationState.ACCEPTED);
+    negotiation.transition(NegotiationState.AGREED);
+    negotiation.transition(NegotiationState.VERIFIED);
+    negotiation.transition(NegotiationState.FINALIZED);
+    expect(negotiation.state).toBe(NegotiationState.FINALIZED);
+  });
+
+  it('rejects invalid transitions', () => {
+    const negotiation = new ContractNegotiation();
+    expect(() => negotiation.transition(NegotiationState.ACCEPTED)).toThrow();
+  });
+
+  it('validates transitions with helper', () => {
+    expect(canTransition(NegotiationState.REQUESTED, NegotiationState.OFFERED)).toBe(true);
+    expect(canTransition(NegotiationState.REQUESTED, NegotiationState.ACCEPTED)).toBe(false);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
-export { default as config } from './config/index.js';
+import config from './config/index.js';
+export { config };
 export * from './logger/index.js';
 export * from './container/index.js';
 export * from './event-bus/index.js';


### PR DESCRIPTION
## Summary
- implement DSP contract negotiation state machine with guarded transitions
- expose state machine via core package and document usage
- fix shared config export and mark negotiation state machine task complete

## Testing
- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- `pnpm test`
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run format:check`
- `npm install --no-package-lock --prefer-offline` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68a397fa3afc832180fd2f5668b8d80a