### PR TITLE
fix: format negotiation test

### DIFF
--- a/packages/control-plane/test/negotiations.e2e.test.ts
+++ b/packages/control-plane/test/negotiations.e2e.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  createServer,
-  InMemoryNegotiationRepository,
-} from '../../core/src/index.js';
+import { createServer, InMemoryNegotiationRepository } from '../../core/src/index.js';
 import { registerNegotiationRoutes } from '../src/routes/negotiations.js';
 
 function setup() {
@@ -21,7 +18,10 @@ describe('negotiation endpoints', () => {
     expect(created).toHaveProperty('@id');
     expect(created).toHaveProperty('state', 'REQUESTED');
 
-    const getRes = await server.inject({ method: 'GET', url: `/dsp/negotiations/${created['@id']}` });
+    const getRes = await server.inject({
+      method: 'GET',
+      url: `/dsp/negotiations/${created['@id']}`,
+    });
     expect(getRes.statusCode).toBe(200);
     expect(getRes.json()).toEqual(created);
   });


### PR DESCRIPTION
## Summary
- fix lint formatting in negotiation e2e test

## Testing
- `pnpm format:check`
- `pnpm lint` *(fails: Cannot find module '@typescript-eslint/scope-manager')*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4edfd3c608321bee2760599111824